### PR TITLE
Fix version conflicts caused by PR#219

### DIFF
--- a/AspNet.WebApi.Server.Example/AspNet.WebApi.Server.Example.csproj
+++ b/AspNet.WebApi.Server.Example/AspNet.WebApi.Server.Example.csproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <SonarQubeExclude>True</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSwag.MSBuild" Version="13.11.3" PrivateAssets="all" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.12.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AspNet.WebApi.Server\AspNet.WebApi.Server.csproj" />

--- a/AspNet.WebApi.Server.Tests/AspNet.WebApi.Server.Tests.csproj
+++ b/AspNet.WebApi.Server.Tests/AspNet.WebApi.Server.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>CS1591;</NoWarn>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.7" />

--- a/AspNet.WebApi.Server/AspNet.WebApi.Server.csproj
+++ b/AspNet.WebApi.Server/AspNet.WebApi.Server.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>True</IsPackable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore" Version="4.2.0" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump NLog.Web.AspNetCore from 4.12.0 to 4.13.0. [(PR#219)](https://github.com/LeonidEfremov/aspnet.webapi.server/pull/219).
Hope this fix can help you.

Best regards,
sucrose